### PR TITLE
libc: arm64: Drop old _mte function variants

### DIFF
--- a/libc/arch-arm64/dynamic_function_dispatch.cpp
+++ b/libc/arch-arm64/dynamic_function_dispatch.cpp
@@ -43,11 +43,7 @@ DEFINE_IFUNC_FOR(memchr) {
 
 typedef int stpcpy_func(char*, const char*);
 DEFINE_IFUNC_FOR(stpcpy) {
-    if (arg->_hwcap2 & HWCAP2_MTE) {
-        RETURN_FUNC(stpcpy_func, __stpcpy_aarch64_mte);
-    } else {
-        RETURN_FUNC(stpcpy_func, __stpcpy_aarch64);
-    }
+    RETURN_FUNC(stpcpy_func, __stpcpy_aarch64);
 }
 
 typedef char* strchr_func(const char*, int);
@@ -70,20 +66,12 @@ DEFINE_IFUNC_FOR(strchrnul) {
 
 typedef int strcmp_func(const char*, const char*);
 DEFINE_IFUNC_FOR(strcmp) {
-    if (arg->_hwcap2 & HWCAP2_MTE) {
-        RETURN_FUNC(strcmp_func, __strcmp_aarch64_mte);
-    } else {
-        RETURN_FUNC(strcmp_func, __strcmp_aarch64);
-    }
+    RETURN_FUNC(strcmp_func, __strcmp_aarch64);
 }
 
 typedef int strcpy_func(char*, const char*);
 DEFINE_IFUNC_FOR(strcpy) {
-    if (arg->_hwcap2 & HWCAP2_MTE) {
-        RETURN_FUNC(strcpy_func, __strcpy_aarch64_mte);
-    } else {
-        RETURN_FUNC(strcpy_func, __strcpy_aarch64);
-    }
+    RETURN_FUNC(strcpy_func, __strcpy_aarch64);
 }
 
 typedef size_t strlen_func(const char*);
@@ -97,11 +85,7 @@ DEFINE_IFUNC_FOR(strlen) {
 
 typedef int strncmp_func(const char*, const char*, int);
 DEFINE_IFUNC_FOR(strncmp) {
-    if (arg->_hwcap2 & HWCAP2_MTE) {
-        RETURN_FUNC(strncmp_func, __strncmp_aarch64_mte);
-    } else {
-        RETURN_FUNC(strncmp_func, __strncmp_aarch64);
-    }
+    RETURN_FUNC(strncmp_func, __strncmp_aarch64);
 }
 
 typedef char* strrchr_func(const char*, int);

--- a/libc/arch-arm64/static_function_dispatch.S
+++ b/libc/arch-arm64/static_function_dispatch.S
@@ -34,13 +34,13 @@ ENTRY(name); \
 END(name)
 
 FUNCTION_DELEGATE(memchr, __memchr_aarch64_mte)
-FUNCTION_DELEGATE(stpcpy, __stpcpy_aarch64_mte)
+FUNCTION_DELEGATE(stpcpy, __stpcpy_aarch64)
 FUNCTION_DELEGATE(strchr, __strchr_aarch64_mte)
 FUNCTION_DELEGATE(strchrnul, __strchrnul_aarch64_mte)
-FUNCTION_DELEGATE(strcmp, __strcmp_aarch64_mte)
-FUNCTION_DELEGATE(strcpy, __strcpy_aarch64_mte)
+FUNCTION_DELEGATE(strcmp, __strcmp_aarch64)
+FUNCTION_DELEGATE(strcpy, __strcpy_aarch64)
 FUNCTION_DELEGATE(strlen, __strlen_aarch64_mte)
 FUNCTION_DELEGATE(strrchr, __strrchr_aarch64_mte)
-FUNCTION_DELEGATE(strncmp, __strncmp_aarch64_mte)
+FUNCTION_DELEGATE(strncmp, __strncmp_aarch64)
 
 NOTE_GNU_PROPERTY()


### PR DESCRIPTION
Since ARM merged the -mte and non-mte versions of strcpy,
stpcpy, strcmp, and strncmp (and dropped mte versions from
android_external_arm-optimized-routines), we need to update
dynamic_function_dispatch & static_function_dispatch to
only resolve to the non-mte routines.
_____
Requires PR#2 in android_external_arm-optimized-routines:
https://github.com/crdroidandroid/android_external_arm-optimized-routines/pull/2