### PR TITLE
bionic: Introduce high performance mimalloc memory allocator

### DIFF
--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -175,6 +175,20 @@ libc32_scudo_product_variables = {
     },
 }
 
+libc_mimalloc_product_variables = {
+    malloc_not_svelte: {
+        cflags: ["-DUSE_MIMALLOC"],
+        whole_static_libs: [
+            "libmimalloc",
+            "libc_mimalloc_wrapper",
+        ],
+        exclude_static_libs: [
+            "libjemalloc5",
+            "libc_jemalloc_wrapper",
+        ],
+    },
+}
+
 
 // Defaults for native allocator libs/includes to make it
 // easier to change.
@@ -211,6 +225,23 @@ cc_library_static {
     // Used to pull in the jemalloc include directory so that if the
     // library is removed, the include directory is also removed.
     static_libs: ["libjemalloc5"],
+}
+
+// Functions not implemented by mimalloc directly, or that need to
+// be modified for Android.
+cc_library_static {
+    name: "libc_mimalloc_wrapper",
+    defaults: ["libc_defaults"],
+    srcs: ["bionic/mimalloc_wrapper.cpp"],
+    cflags: ["-fvisibility=hidden"],
+
+    // Used to pull in the mimalloc include directory so that if the
+    // library is removed, the include directory is also removed.
+    static_libs: ["libmimalloc"],
+
+    apex_available: [
+        "com.android.runtime",
+    ],
 }
 
 // ========================================================
@@ -2023,6 +2054,7 @@ cc_library_headers {
         "//external/arm-optimized-routines",
         "//external/gwp_asan",
         "//external/jemalloc_new",
+        "//external/mimalloc",
         "//external/libunwind_llvm",
         "//external/scudo",
         "//system/core/property_service/libpropertyinfoparser",

--- a/libc/Android.bp
+++ b/libc/Android.bp
@@ -204,14 +204,7 @@ cc_defaults {
         "libc_jemalloc_wrapper",
     ],
     header_libs: ["gwp_asan_headers"],
-    multilib: {
-        lib64: {
-            product_variables: libc_scudo_product_variables,
-        },
-        lib32: {
-            product_variables: libc32_scudo_product_variables,
-        }
-    },
+    product_variables: libc_mimalloc_product_variables,
 }
 
 // Functions not implemented by jemalloc directly, or that need to

--- a/libc/Android.bp.orig
+++ b/libc/Android.bp.orig
@@ -119,6 +119,38 @@ cc_defaults {
     // warning since this is intended right now.
     ldflags: ["-Wl,-z,muldefs"],
 
+<<<<<<< HEAD
+    multilib: {
+        lib64: {
+            product_variables: {
+                malloc_zero_contents: {
+                    cflags: ["-DSCUDO_ZERO_CONTENTS"],
+                },
+                malloc_pattern_fill_contents: {
+                    cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
+                },
+                malloc_not_svelte: {
+                    cflags: ["-DUSE_SCUDO"],
+                },
+            },
+        },
+        lib32: {
+            product_variables: {
+                malloc_zero_contents: {
+                    cflags: ["-DSCUDO_ZERO_CONTENTS"],
+                },
+                malloc_pattern_fill_contents: {
+                    cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
+                },
+                malloc_not_svelte_libc32: {
+                    cflags: ["-DUSE_SCUDO"],
+                },
+            },
+        },
+    },
+
+=======
+>>>>>>> 4d0e2c21e (bionic: Don't explicitly set scudo in common parts)
     lto: {
         never: true,
     },
@@ -126,11 +158,11 @@ cc_defaults {
 
 libc_scudo_product_variables = {
     malloc_zero_contents: {
-        cflags: ["-DSCUDO_ZERO_CONTENTS"],
-    },
-    malloc_pattern_fill_contents: {
-        cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
-    },
+            cflags: ["-DSCUDO_ZERO_CONTENTS"],
+        },
+        malloc_pattern_fill_contents: {
+            cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
+        },
     malloc_not_svelte: {
         cflags: ["-DUSE_SCUDO"],
         whole_static_libs: ["libscudo"],
@@ -142,12 +174,6 @@ libc_scudo_product_variables = {
 }
 
 libc32_scudo_product_variables = {
-    malloc_zero_contents: {
-        cflags: ["-DSCUDO_ZERO_CONTENTS"],
-    },
-    malloc_pattern_fill_contents: {
-        cflags: ["-DSCUDO_PATTERN_FILL_CONTENTS"],
-    },
     malloc_not_svelte_libc32: {
         cflags: ["-DUSE_SCUDO"],
         whole_static_libs: ["libscudo"],
@@ -1322,10 +1348,7 @@ cc_library_static {
 // ========================================================
 
 cc_library_static {
-    defaults: [
-        "libc_defaults",
-        "target_alternative_futex_waiters_defaults"
-    ],
+    defaults: ["libc_defaults"],
     srcs: [
         "bionic/bionic_elf_tls.cpp",
         "bionic/pthread_atfork.cpp",

--- a/libc/bionic/malloc_common.h
+++ b/libc/bionic/malloc_common.h
@@ -65,6 +65,11 @@ __END_DECLS
 #include "scudo.h"
 #define Malloc(function)  scudo_svelte_ ## function
 
+#elif defined(USE_MIMALLOC)
+
+#include "mimalloc_wrapper.h"
+#define Malloc(function)  mi_ ## function
+
 #else
 
 #include "jemalloc.h"

--- a/libc/bionic/mimalloc_wrapper.cpp
+++ b/libc/bionic/mimalloc_wrapper.cpp
@@ -42,11 +42,6 @@ int mi_malloc_info(int /*options*/, FILE* /*fp*/) {
   return -1;
 }
 
-struct mallinfo mi_mallinfo() {
-  struct mallinfo info {};
-  return info;
-}
-
 // libmemunreachable is not supported
 void mi_malloc_disable() {
 }

--- a/libc/bionic/mimalloc_wrapper.cpp
+++ b/libc/bionic/mimalloc_wrapper.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 The ProtonAOSP Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "mimalloc_wrapper.h"
+
+// Changing decay rate is not supported for now
+int mi_mallopt(int /*param*/, int /*value*/) {
+  return 0;
+}
+
+// Info dumps are not supported
+int mi_malloc_info(int /*options*/, FILE* /*fp*/) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+struct mallinfo mi_mallinfo() {
+  struct mallinfo info {};
+  return info;
+}
+
+// libmemunreachable is not supported
+void mi_malloc_disable() {
+}
+
+void mi_malloc_enable() {
+}
+
+int mi_malloc_iterate(uintptr_t, size_t, void (*)(uintptr_t, size_t, void*), void*) {
+  return 0;
+}

--- a/libc/bionic/mimalloc_wrapper.h
+++ b/libc/bionic/mimalloc_wrapper.h
@@ -39,7 +39,6 @@ __BEGIN_DECLS
 
 int mi_mallopt(int, int);
 int mi_malloc_info(int, FILE*);
-struct mallinfo mi_mallinfo();
 
 void mi_malloc_disable();
 void mi_malloc_enable();

--- a/libc/bionic/mimalloc_wrapper.h
+++ b/libc/bionic/mimalloc_wrapper.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021 The ProtonAOSP Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <mimalloc.h>
+
+#include <private/bionic_config.h>
+
+__BEGIN_DECLS
+
+int mi_mallopt(int, int);
+int mi_malloc_info(int, FILE*);
+struct mallinfo mi_mallinfo();
+
+void mi_malloc_disable();
+void mi_malloc_enable();
+int mi_malloc_iterate(uintptr_t, size_t, void (*)(uintptr_t, size_t, void*), void*);
+
+__END_DECLS


### PR DESCRIPTION
mimalloc [1] is a general-purpose memory allocator (similar to jemalloc)
with better performance and lower memory usage than both jemalloc and Scudo.

Additional repo for mimalloc is required [android_external_mimalloc](https://github.com/AcmeUI/android_external_mimalloc/commits/taffy)

[1] https://github.com/microsoft/mimalloc